### PR TITLE
Tweak bazel setup for building from non-Linux systems

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,6 @@
+# Produce linux-amd64 binaries by default as expected by our container images. 
+# To run tests on the local machine, use `bazel test --platforms="" pkg/...`.
+build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64
+
+# Allow loading produced container images to other Docker Daemons.
+build --action_env=DOCKER_HOST --action_env=DOCKER_TLS_VERIFY --action_env=DOCKER_CERT_PATH --action_env=DOCKER_API_VERSION

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,3 +203,20 @@ docker volume prune
 docker image prune --all --filter until=720h
 ```
 
+## Common Problems
+
+### Testing builder with `pack build` fails
+
+Run `pack build ... -v` to produce more verbose debug output.
+
+### `bazel test` fails on macOS or Windows 
+
+By default, `bazel` builds Go binaries for the current platform.  As GCP Buildpacks
+are targeted to Linux-based container images, our `.bazelrc` configures builds for
+the Linux AMD64 platform by default.
+
+To run tests on the local platform, override the `--plaforms` as
+follows:
+```sh
+bazel test --platforms="" pkg/...
+```


### PR DESCRIPTION
Building from macOS can produce unexpected results as Bazel's `rules_go` build binaries for the current platform by default.  But our container images are expected to be linux-amd64.

This PR does the following:
  - adds to the `.bazelrc` to configure bazel to build linux-amd64 binaries by default
  - adds to the `.bazelrc` to pass through Docker-relevant environment variables to allow loading the images to minikube (for example), which is helpful for testing from Skaffold
  - adds to the `CONTRIBUTING.md` to describe how to override the `--platforms` flag to test locally 
