### PR TITLE
Support polyglot maven builds (no pom.xml)

### DIFF
--- a/builders/gcp/base/acceptance/java_test.go
+++ b/builders/gcp/base/acceptance/java_test.go
@@ -89,11 +89,24 @@ func TestAcceptanceJava(t *testing.T) {
 			MustNotUse: []string{javaEntrypoint},
 		},
 		{
+			Name:       "Java gradle",
+			App:        "java/gradle_micronaut",
+			Env:        []string{"GOOGLE_ENTRYPOINT=java -jar build/libs/helloworld-0.1-all.jar"},
+			MustUse:    []string{javaGradle, javaRuntime, entrypoint},
+			MustNotUse: []string{javaEntrypoint},
+		},
+		{
 			Name:                "Java gradle (Dev Mode)",
 			App:                 "java/gradle_micronaut",
 			Env:                 []string{"GOOGLE_DEVMODE=1"},
 			FilesMustExist:      []string{"/layers/google.java.gradle/cache", "/layers/google.java.gradle/cache/bin/.devmode_rebuild.sh"},
 			MustRebuildOnChange: "/workspace/src/main/java/example/HelloController.java",
+		},
+		{
+			Name:       "polyglot maven",
+			App:        "java/polyglot-maven",
+			MustUse:    []string{javaMaven, javaRuntime, javaEntrypoint},
+			MustNotUse: []string{entrypoint},
 		},
 		{
 			Name:       "Maven build args",

--- a/builders/testdata/generic/java/polyglot-maven/.mvn/extensions.xml
+++ b/builders/testdata/generic/java/polyglot-maven/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>io.takari.polyglot</groupId>
+    <artifactId>polyglot-yaml</artifactId>
+    <version>0.4.5</version>
+  </extension>
+</extensions>

--- a/builders/testdata/generic/java/polyglot-maven/pom.yml
+++ b/builders/testdata/generic/java/polyglot-maven/pom.yml
@@ -1,0 +1,18 @@
+modelVersion: 4.0.0
+groupId: main
+artifactId: polyglot-maven
+version: 0.1
+
+properties:
+  maven.compiler.target: 11
+  maven.compiler.source: 11
+
+build:
+  plugins:
+  - groupId: org.apache.maven.plugins
+    artifactId: maven-jar-plugin
+    version: 3.2.0
+    configuration:
+      archive:
+        manifest:
+          mainClass: main.Main

--- a/builders/testdata/generic/java/polyglot-maven/src/main/java/main/Main.java
+++ b/builders/testdata/generic/java/polyglot-maven/src/main/java/main/Main.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+public class Main {
+
+  public static void main(String[] args) throws IOException {
+    // Create an instance of HttpServer bound to port defined by the
+    // PORT environment variable when present, otherwise on 8080.
+    int port = Integer.parseInt(System.getenv().getOrDefault("PORT", "8080"));
+    HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
+
+    // Set root URI path.
+    server.createContext(
+        "/",
+        (var t) -> {
+          byte[] response = "PASS".getBytes();
+          t.sendResponseHeaders(200, response.length);
+          try (OutputStream os = t.getResponseBody()) {
+            os.write(response);
+          }
+        });
+
+    server.start();
+  }
+}

--- a/cmd/java/maven/main.go
+++ b/cmd/java/maven/main.go
@@ -45,8 +45,8 @@ func main() {
 }
 
 func detectFn(ctx *gcp.Context) error {
-	if !ctx.FileExists("pom.xml") {
-		ctx.OptOut("pom.xml not found.")
+	if !ctx.FileExists("pom.xml") && !ctx.FileExists(".mvn/extensions.xml") {
+		ctx.OptOut("None of the following found: pom.xml or .mvn/extensions.xml.")
 	}
 	return nil
 }

--- a/cmd/java/maven/main_test.go
+++ b/cmd/java/maven/main_test.go
@@ -34,6 +34,13 @@ func TestDetect(t *testing.T) {
 			want: 0,
 		},
 		{
+			name: ".mvn/extensions.xml",
+			files: map[string]string{
+				".mvn/extensions.xml": "",
+			},
+			want: 0,
+		},
+		{
 			name:  "no pom.xml",
 			files: map[string]string{},
 			want:  100,

--- a/cmd/java/runtime/main.go
+++ b/cmd/java/runtime/main.go
@@ -43,6 +43,7 @@ func detectFn(ctx *gcp.Context) error {
 	runtime.CheckOverride(ctx, "java")
 
 	if ctx.FileExists("pom.xml") ||
+		ctx.FileExists(".mvn/extensions.xml") ||
 		ctx.FileExists("build.gradle") ||
 		ctx.FileExists("build.gradle.kts") ||
 		ctx.FileExists("META-INF/MANIFEST.MF") ||
@@ -50,7 +51,7 @@ func detectFn(ctx *gcp.Context) error {
 		len(ctx.Glob("*.jar")) > 0 {
 		return nil
 	}
-	ctx.OptOut("None of the following found: pom.xml, build.gradle, build.gradle.kts, META-INF/MANIFEST.MF, *.java, *.jar.")
+	ctx.OptOut("None of the following found: pom.xml, .mvn/extensions.xml, build.gradle, build.gradle.kts, META-INF/MANIFEST.MF, *.java, *.jar.")
 	return nil
 }
 

--- a/cmd/java/runtime/main_test.go
+++ b/cmd/java/runtime/main_test.go
@@ -35,6 +35,13 @@ func TestDetect(t *testing.T) {
 			want: 0,
 		},
 		{
+			name: ".mvn/extensions.xml",
+			files: map[string]string{
+				".mvn/extensions.xml": "",
+			},
+			want: 0,
+		},
+		{
 			name: "build.gradle",
 			files: map[string]string{
 				"build.gradle": "",


### PR DESCRIPTION
This PR adds support for building [Polyglot Maven](https://github.com/takari/polyglot-maven/) projects.  Polyglot Maven allows using alternative representations for the `pom.xml` file, including YAML, Groovy, Scala, and more.  The interpreter is pulled in via a `.mvn/extensions.xml` file.

An example is included in `testdata/generic/java/polyglot-maven` and used in the gcp/base acceptance tests.