### PR TITLE
feat: add GOOGLE_CLEAR_SOURCE_EXCLUDE env

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ The following confguration options are supported across runtimes:
   * Clears source after the application is built. If the application depends on static files, such as Go templates, setting this variable may cause the application to misbehave.
   * *(Only applicable to Go apps and Java apps & functions.)*
   * **Example:** `true`, `True`, `1` will clear the source.
+* `GOOGLE_CLEAR_SOURCE_EXCLUDE`
+  * Specifies colon separated glob patterns to be excluded from being cleared when `GOOGLE_CLEAR_SOURCE` is specified.
+  * *(Only applicable to Go apps and Java apps & functions.)*
+  * **Example:** `templates`, `templates:migrations`   
 
 Certain buildpacks support other environment variables:
 

--- a/builders/gcp/base/acceptance/go_test.go
+++ b/builders/gcp/base/acceptance/go_test.go
@@ -90,6 +90,14 @@ func TestAcceptanceGo(t *testing.T) {
 			FilesMustExist:    []string{"/layers/google.go.build/bin/main"},
 			FilesMustNotExist: []string{"/layers/google.go.runtime", "/workspace/main.go"},
 		},
+		{
+			Name:              "clear source with excludes",
+			App:               "go/simple",
+			Env:               []string{"GOOGLE_CLEAR_SOURCE=true", "GOOGLE_CLEAR_SOURCE_EXCLUDE=main.*"},
+			MustUse:           []string{goClearSource},
+			FilesMustExist:    []string{"/layers/google.go.build/bin/main"},
+			FilesMustNotExist: []string{"/layers/google.go.runtime"},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc

--- a/builders/gcp/base/acceptance/go_test.go
+++ b/builders/gcp/base/acceptance/go_test.go
@@ -95,7 +95,7 @@ func TestAcceptanceGo(t *testing.T) {
 			App:               "go/simple",
 			Env:               []string{"GOOGLE_CLEAR_SOURCE=true", "GOOGLE_CLEAR_SOURCE_EXCLUDE=main.*"},
 			MustUse:           []string{goClearSource},
-			FilesMustExist:    []string{"/layers/google.go.build/bin/main"},
+			FilesMustExist:    []string{"/layers/google.go.build/bin/main", "/workspace/main.go"},
 			FilesMustNotExist: []string{"/layers/google.go.runtime"},
 		},
 	}

--- a/builders/gcp/base/acceptance/java_test.go
+++ b/builders/gcp/base/acceptance/java_test.go
@@ -130,6 +130,15 @@ func TestAcceptanceJava(t *testing.T) {
 			FilesMustNotExist: []string{"/workspace/src/main/java/hello/Hello.java", "/workspace/pom.xml"},
 		},
 		{
+			Name:              "Maven with source clearing and excludes",
+			App:               "java/hello_quarkus_maven",
+			Env:               []string{"GOOGLE_CLEAR_SOURCE=true", "GOOGLE_CLEAR_SOURCE_EXLCUDE=pom.xml"},
+			MustUse:           []string{javaMaven, javaRuntime, javaEntrypoint, javaClearSource},
+			MustNotUse:        []string{entrypoint},
+			FilesMustExist:    []string{"/workspace/target/hello-1-runner.jar"},
+			FilesMustNotExist: []string{"/workspace/src/main/java/hello/Hello.java"},
+		},
+		{
 			Name:              "Gradle with source clearing",
 			App:               "java/gradle_micronaut",
 			Env:               []string{"GOOGLE_CLEAR_SOURCE=true", "GOOGLE_ENTRYPOINT=java -jar build/libs/helloworld-0.1-all.jar"},

--- a/builders/gcp/base/acceptance/java_test.go
+++ b/builders/gcp/base/acceptance/java_test.go
@@ -135,7 +135,7 @@ func TestAcceptanceJava(t *testing.T) {
 			Env:               []string{"GOOGLE_CLEAR_SOURCE=true", "GOOGLE_CLEAR_SOURCE_EXLCUDE=pom.xml"},
 			MustUse:           []string{javaMaven, javaRuntime, javaEntrypoint, javaClearSource},
 			MustNotUse:        []string{entrypoint},
-			FilesMustExist:    []string{"/workspace/target/hello-1-runner.jar"},
+			FilesMustExist:    []string{"/workspace/target/hello-1-runner.jar", "/workspace/pom.xml"},
 			FilesMustNotExist: []string{"/workspace/src/main/java/hello/Hello.java"},
 		},
 		{

--- a/pkg/clearsource/clearsource.go
+++ b/pkg/clearsource/clearsource.go
@@ -65,7 +65,7 @@ func BuildFn(ctx *gcp.Context, exclusions []string) error {
 		ctx.Span("Clear source", now, gcp.StatusOk)
 	}(time.Now())
 
-	userExclusions := strings.Split(strings.TrimSpace(os.Getenv(env.ClearSourceExclude)), ":")
+	userExclusions := strings.Split(os.Getenv(env.ClearSourceExclude), ":")
 
 	exclusions = append(exclusions, defaultExclusions...)
 	exclusions = append(exclusions, userExclusions...)

--- a/pkg/clearsource/clearsource.go
+++ b/pkg/clearsource/clearsource.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/buildpacks/pkg/appengine"
@@ -64,7 +65,11 @@ func BuildFn(ctx *gcp.Context, exclusions []string) error {
 		ctx.Span("Clear source", now, gcp.StatusOk)
 	}(time.Now())
 
+	userExclusions := strings.Split(strings.TrimSpace(os.Getenv(env.ClearSourceExclude)), ":")
+
 	exclusions = append(exclusions, defaultExclusions...)
+	exclusions = append(exclusions, userExclusions...)
+
 	paths, err := pathsToRemove(ctx, ctx.ApplicationRoot(), exclusions)
 	if err != nil {
 		return fmt.Errorf("filtering paths: %w", err)

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -49,6 +49,12 @@ const (
 	// Buildpacks for Go and Java support clearing the source.
 	ClearSource = "GOOGLE_CLEAR_SOURCE"
 
+	// ClearSourceExclude is an env var used to specify glob patterns to be excluded from clear source files from the final image.
+	// Mulitple patters can be specified by separating them by ':'.
+	// Buildpacks for Go and Java support clearing the source.
+	// Example: 'templates'
+	ClearSourceExclude = "GOOGLE_CLEAR_SOURCE_EXCLUDE"
+
 	// Buildable is an env var used to specify the buildable unit to build.
 	// Buildable should be respected by buildpacks that build source.
 	// Example: `./maindir` for Go will build the package rooted at maindir.

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -52,7 +52,7 @@ const (
 	// ClearSourceExclude is an env var used to specify glob patterns to be excluded from clear source files from the final image.
 	// Mulitple patters can be specified by separating them by ':'.
 	// Buildpacks for Go and Java support clearing the source.
-	// Example: 'templates'
+	// Example: 'templates' or 'templates:migrations'
 	ClearSourceExclude = "GOOGLE_CLEAR_SOURCE_EXCLUDE"
 
 	// Buildable is an env var used to specify the buildable unit to build.


### PR DESCRIPTION
`GOOGLE_CLEAR_SOURCE_EXCLUDE` specifies colon separated glob patterns to be excluded from being cleared when `GOOGLE_CLEAR_SOURCE` is set.