### PR TITLE
Use proper NODE_ENV when generating lock file.

### DIFF
--- a/builders/gae/nodejs10/acceptance/acceptance_test.go
+++ b/builders/gae/nodejs10/acceptance/acceptance_test.go
@@ -170,6 +170,11 @@ func TestAcceptance(t *testing.T) {
 			MustUse:    []string{yarn},
 			MustNotUse: []string{npm},
 		},
+		{
+			App:        "private_dev_dependency_npm",
+			MustUse:    []string{npm},
+			MustNotUse: []string{yarn},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc

--- a/builders/gae/nodejs12/acceptance/acceptance_test.go
+++ b/builders/gae/nodejs12/acceptance/acceptance_test.go
@@ -162,6 +162,11 @@ func TestAcceptance(t *testing.T) {
 			MustUse:    []string{npm},
 			MustNotUse: []string{yarn},
 		},
+		{
+			App:        "private_dev_dependency_npm",
+			MustUse:    []string{npm},
+			MustNotUse: []string{yarn},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc

--- a/builders/gae/nodejs14/acceptance/acceptance_test.go
+++ b/builders/gae/nodejs14/acceptance/acceptance_test.go
@@ -162,6 +162,11 @@ func TestAcceptance(t *testing.T) {
 			MustUse:    []string{npm},
 			MustNotUse: []string{yarn},
 		},
+		{
+			App:        "private_dev_dependency_npm",
+			MustUse:    []string{npm},
+			MustNotUse: []string{yarn},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc

--- a/builders/testdata/nodejs/private_dev_dependency_npm/package.json
+++ b/builders/testdata/nodejs/private_dev_dependency_npm/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "polka": ">=0.5.2"
+  },
+  "devDependencies": {
+    "@internal/private": "0"
+  }
+}

--- a/builders/testdata/nodejs/private_dev_dependency_npm/server.js
+++ b/builders/testdata/nodejs/private_dev_dependency_npm/server.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Application that verifies the installed version of Polka.
+ *
+ * The installed version should match the one specified in package-lock.json.
+ */
+
+'use strict';
+
+const polka = require('polka');
+const ppkg = require('polka/package.json');
+
+polka()
+  .get('/', (req, response) => {
+    response.writeHead(200, {"Content-Type": "text/plain"});
+    let want = "0.5.2";
+    let got = ppkg.version;
+    if (want != got) {
+      response.end(`Unexpected polka version: got ${got}, want ${want}`);
+    } else {
+      response.end("PASS");
+    }
+  })
+  .listen(process.env.PORT);

--- a/cmd/nodejs/npm/main.go
+++ b/cmd/nodejs/npm/main.go
@@ -46,9 +46,9 @@ func buildFn(ctx *gcp.Context) error {
 	nm := filepath.Join(ml.Path, "node_modules")
 	ctx.RemoveAll("node_modules")
 
-	lockfile := nodejs.EnsureLockfile(ctx)
-
 	nodeEnv := nodejs.NodeEnv()
+	lockfile := nodejs.EnsureLockfile(ctx, nodeEnv)
+
 	cached, err := nodejs.CheckCache(ctx, ml, cache.WithStrings(nodeEnv), cache.WithFiles("package.json", lockfile))
 	if err != nil {
 		return fmt.Errorf("checking cache: %w", err)

--- a/cmd/nodejs/npm_gcp_build/main.go
+++ b/cmd/nodejs/npm_gcp_build/main.go
@@ -54,9 +54,9 @@ func buildFn(ctx *gcp.Context) error {
 	nm := filepath.Join(l.Path, "node_modules")
 	ctx.RemoveAll("node_modules")
 
-	lockfile := nodejs.EnsureLockfile(ctx)
-
 	nodeEnv := nodejs.EnvDevelopment
+	lockfile := nodejs.EnsureLockfile(ctx, nodeEnv)
+
 	cached, err := nodejs.CheckCache(ctx, l, cache.WithStrings(nodeEnv), cache.WithFiles("package.json", lockfile))
 	if err != nil {
 		return fmt.Errorf("checking cache: %w", err)

--- a/pkg/nodejs/npm.go
+++ b/pkg/nodejs/npm.go
@@ -28,7 +28,7 @@ const (
 )
 
 // EnsureLockfile returns the name of the lockfile, generating a package-lock.json if necessary.
-func EnsureLockfile(ctx *gcp.Context) string {
+func EnsureLockfile(ctx *gcp.Context, nodeEnv string) string {
 	// npm prefers npm-shrinkwrap.json, see https://docs.npmjs.com/cli/shrinkwrap.
 	if ctx.FileExists(NPMShrinkwrap) {
 		return NPMShrinkwrap
@@ -36,7 +36,7 @@ func EnsureLockfile(ctx *gcp.Context) string {
 	if !ctx.FileExists(PackageLock) {
 		ctx.Logf("Generating %s.", PackageLock)
 		ctx.Warnf("*** Improve build performance by generating and committing %s.", PackageLock)
-		ctx.Exec([]string{"npm", "install", "--package-lock-only", "--quiet"}, gcp.WithUserAttribution)
+		ctx.Exec([]string{"npm", "install", "--package-lock-only", "--quiet"}, gcp.WithEnv("NODE_ENV="+nodeEnv), gcp.WithUserAttribution)
 	}
 	return PackageLock
 }


### PR DESCRIPTION
If package-lock.json is absent and NODE_ENV=production, generating lock without
NODE_ENV=production causes error if devDependencies contain packages from
private repositories. This change makes devDependencies ignored.