### PR TITLE
applicationRoot setter

### DIFF
--- a/pkg/gcpbuildpack/gcpbuildpack.go
+++ b/pkg/gcpbuildpack/gcpbuildpack.go
@@ -161,6 +161,11 @@ func (ctx *Context) Processes() []libcnb.Process {
 	return ctx.buildResult.Processes
 }
 
+// WithApplicationRoot set applicationRoot.
+func (ctx *Context) WithApplicationRoot(applicationRoot string) {
+	ctx.applicationRoot = applicationRoot
+}
+
 // Main is the main entrypoint to a buildpack's detect and build functions.
 func Main(d DetectFn, b BuildFn) {
 	switch filepath.Base(os.Args[0]) {


### PR DESCRIPTION
I'm using `buildpacks` as a vendor package and I'm not able to set `applicationRoot`. The only way to achieve that is to use `NewContextForTests` but it seems like a bad idea in production.