### PR TITLE
Update README.md for GOOGLE_BUILDABLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The following confguration options are supported across runtimes:
   * **Example:** `13.7.0` for Node.js, `1.14.1` for Go, `8` for Java, `3.1.301` for .NET.
 * `GOOGLE_BUILDABLE`
   * Specifies path to a buildable unit.
-  * *(Only applicable to compiled languages.)*
+  * *(Only applicable to Go, .NET and Dart languages.)*
   * **Example:** `./maindir` for Go will build the package rooted at maindir.
 * `GOOGLE_BUILD_ARGS`
   * Appends arguments to build command.


### PR DESCRIPTION
As explained here https://github.com/GoogleCloudPlatform/buildpacks, not all compiled languages have support for setting GOOGLE_BUILDABLE.
This is to list only supported languages to not confuse developers.