### PR TITLE
Add gradlew support to gcf

### DIFF
--- a/pkg/java/java.go
+++ b/pkg/java/java.go
@@ -183,3 +183,16 @@ func MvnCmd(ctx *gcp.Context) (string, error) {
 	}
 	return "mvn", nil
 }
+
+// GradleCmd returns the command that should be used to invoke gradle for this build.
+func GradleCmd(ctx *gcp.Context) (string, error) {
+	exists, err := ctx.FileExists("gradlew")
+	if err != nil {
+		return "", err
+	}
+	// If this project has the Gradle Wrapper, we should use it
+	if exists {
+		return "./gradlew", nil
+	}
+	return "gradle", nil
+}


### PR DESCRIPTION
Similar to what happens to `mvnw`, I've added support for `gradlew` when running a gcf.

I've faced some issues when deploying a function to Google when my project contains a `gradlew` as part of it and had to investigate a bit on the problem. I am not completely sure this is going to fix the problem I am facing but it sounds like a good addition to the project anyhow.

For reference, you can check how maven cmd/pkg is doing this:
- https://github.com/GoogleCloudPlatform/buildpacks/blob/main/pkg/java/java.go#L174-L185
- https://github.com/GoogleCloudPlatform/buildpacks/blob/main/cmd/java/functions_framework/main.go#L146-L149