### PR TITLE
Do not decorate php-fpm worker output

### DIFF
--- a/pkg/nginx/nginx.go
+++ b/pkg/nginx/nginx.go
@@ -59,6 +59,7 @@ pm.max_children = {{.NumWorkers}}
 clear_env = no
 
 catch_workers_output = yes
+decorate_workers_output = no
 `))
 
 // NginxTemplate is a template that produces a snippet of nginx config that sets up the


### PR DESCRIPTION
Structured logging by writing JSON to stdout/stderr is not working as expected with the current version of the php buildpack. By default, php-fpm will prefix output written to stdout/stderr by applications. For example, when the application writes `{"message":"foo"}` to stdout, this currently renders as:

```
WARNING: [pool app] child 19 said into stdout: {"message":"foo"}
```

This breaks parsing JSON logs since the line is not valid JSON. Setting `decorate_workers_output = no` will prevent php-fpm from adding this prefix.