### PR TITLE
migrate from AdoptOpenJDK API to Adoptium

### DIFF
--- a/cmd/java/runtime/main.go
+++ b/cmd/java/runtime/main.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	javaLayer             = "java"
-	javaVersionURL        = "https://api.adoptopenjdk.net/v3/assets/feature_releases/%s/ga?architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&os=linux&page=0&page_size=1&project=jdk&sort_order=DESC&vendor=adoptopenjdk"
+	javaVersionURL        = "https://api.adoptium.net/v3/assets/feature_releases/%s/ga?architecture=x64&heap_size=normal&image_type=jdk&jvm_impl=hotspot&os=linux&page=0&page_size=1&project=jdk&sort_order=DESC&vendor=eclipse"
 	defaultFeatureVersion = "11"
 	versionKey            = "version"
 )


### PR DESCRIPTION
The AdoptOpenJDK API has been deprecated for some time in favour of the Eclipse Temurin API