### PR TITLE
Support composer gcp-build on gcp + cloud-run

### DIFF
--- a/builders/php/builder.toml
+++ b/builders/php/builder.toml
@@ -113,6 +113,10 @@ description = "Unified builder for the PHP runtime"
     optional = true
 
   [[order.group]]
+    id = "google.php.composer-gcp-build"
+    optional = true
+
+  [[order.group]]
     id = "google.php.composer"
     optional = true
 


### PR DESCRIPTION
`gcp-build` composer script handling is an excellent tool to add custom steps to deployment in Google Cloud. It's already handled by AppEngine, and I see no reason it shouldn't be handled by CloudRun.

All it does is run extra script in case composer.json go `gcp-build` scripts variable set.

Example: https://github.com/GoogleCloudPlatform/buildpacks/blob/559569a89fe05b1ca6bd4eb6c2fb6412df8b10a7/builders/testdata/php/appengine/gcp_build_no_dependencies/composer.json#L2