### PR TITLE
Add PHP runtime config option to enable serving static files

### DIFF
--- a/builders/php/acceptance/flex_test.go
+++ b/builders/php/acceptance/flex_test.go
@@ -35,6 +35,23 @@ func TestAcceptance(t *testing.T) {
 			MustUse:                    []string{flex, utilsNginx},
 			MustMatch:                  "app.php",
 		},
+		{
+			Name:                       "serves static files",
+			App:                        "serves_static_files",
+			Env:                        []string{"NGINX_SERVES_STATIC_FILES=true"},
+			VersionInclusionConstraint: "< 8.2.0",
+			MustUse:                    []string{flex, utilsNginx},
+			Path:                       "/hello.txt",
+			MustMatch:                  "hello world",
+		},
+		{
+			Name:                       "does not serve static files",
+			App:                        "serves_static_files",
+			VersionInclusionConstraint: "< 8.2.0",
+			MustUse:                    []string{flex, utilsNginx},
+			Path:                       "/hello.txt",
+			MustMatch:                  "index.php",
+		},
 	}
 
 	for _, tc := range acceptance.FilterTests(t, imageCtx, testCases) {

--- a/builders/testdata/php/flex/serves_static_files/app.yaml
+++ b/builders/testdata/php/flex/serves_static_files/app.yaml
@@ -1,0 +1,5 @@
+runtime: php
+env: flex
+
+runtime_config:
+  document_root: .

--- a/builders/testdata/php/flex/serves_static_files/hello.txt
+++ b/builders/testdata/php/flex/serves_static_files/hello.txt
@@ -1,0 +1,1 @@
+hello world

--- a/builders/testdata/php/flex/serves_static_files/index.php
+++ b/builders/testdata/php/flex/serves_static_files/index.php
@@ -1,0 +1,3 @@
+<?php
+
+echo 'index.php';

--- a/cmd/php/webconfig/main.go
+++ b/cmd/php/webconfig/main.go
@@ -87,6 +87,12 @@ func buildFn(ctx *gcp.Context) error {
 		overrides.NginxConfOverrideFileName = filepath.Join(defaultRoot, customNginxConf)
 	}
 
+	nginxServesStaticFiles, err := env.IsPresentAndTrue(php.NginxServesStaticFiles);
+	if err != nil {
+		return err
+	}
+	overrides.NginxServesStaticFiles = nginxServesStaticFiles
+
 	fpmConfFile, err := writeFpmConfig(ctx, l.Path, overrides)
 	if err != nil {
 		return err
@@ -247,6 +253,7 @@ func nginxConfig(layer string, overrides webconfig.OverrideProperties) nginx.Con
 		FrontControllerScript: frontController,
 		Root:                  root,
 		AppListenAddress:      "unix:" + filepath.Join(layer, appSocket),
+		ServesStaticFiles:     overrides.NginxServesStaticFiles,
 	}
 
 	if env.IsFlex() {

--- a/pkg/nginx/nginx.go
+++ b/pkg/nginx/nginx.go
@@ -90,7 +90,13 @@ server {
 	server_name	"";
 	root	{{.Root}};
 
+	{{if .ServesStaticFiles}}
+	location / {
+		try_files $uri /{{.FrontControllerScript}}$uri;
+	}
+	{{else}}
 	rewrite	^/(.*)$	/{{.FrontControllerScript}}$uri;
+	{{end}}
 
 	location	~	^/{{.FrontControllerScript}}	{
 		error_log stderr;
@@ -161,6 +167,7 @@ type Config struct {
 	AppListenAddress      string
 	FrontControllerScript string
 	NginxConfInclude      string
+	ServesStaticFiles     bool
 }
 
 const (

--- a/pkg/php/php.go
+++ b/pkg/php/php.go
@@ -90,6 +90,9 @@ post_max_size = 32M
 
 	// CustomNginxConfig is an environment variable to pass a custom nginx configuration.
 	CustomNginxConfig = "GOOGLE_CUSTOM_NGINX_CONFIG"
+
+	// NginxServesStaticFiles is an environment variable to configure Nginx to serve static files.
+	NginxServesStaticFiles = "NGINX_SERVES_STATIC_FILES"
 )
 
 type composerScriptsJSON struct {

--- a/pkg/webconfig/webconfig.go
+++ b/pkg/webconfig/webconfig.go
@@ -52,6 +52,8 @@ type OverrideProperties struct {
 	PHPIniOverride bool
 	// PHPIniOverrideFileName name of the user-provided php ini config.
 	PHPIniOverrideFileName string
+	// NginxServesStaticFiles whether Nginx also serves static files for matching URIs.
+	NginxServesStaticFiles bool
 }
 
 // OverriddenProperties returns whether the property has been overridden and the path to the file.


### PR DESCRIPTION
It's a common use case to allow PHP app serve static files with popular frameworks like Laravel. This should still be not enabled by default since some use cases specifically do not want to expose static files.