### PR TITLE
Allow override nginx document root via environment variable

### DIFF
--- a/builders/php/acceptance/flex_test.go
+++ b/builders/php/acceptance/flex_test.go
@@ -22,6 +22,15 @@ func TestAcceptance(t *testing.T) {
 			MustUse:                    []string{flex, composer},
 		},
 		{
+			Name:                       "overridden document root",
+			App:                        "front_controller",
+			VersionInclusionConstraint: "< 8.2.0",
+			MustUse:                    []string{flex, composer},
+			Env:                        []string{"NGINX_DOCUMENT_ROOT=public"},
+			Path:                       "/",
+			MustMatch:                  "from public dir",
+		},
+		{
 			Name:                       "php ini override",
 			App:                        "php_ini",
 			MustMatch:                  "PASS_PHP_INI",

--- a/builders/testdata/php/flex/front_controller/public/app.php
+++ b/builders/testdata/php/flex/front_controller/public/app.php
@@ -1,0 +1,1 @@
+from public dir

--- a/cmd/php/webconfig/main.go
+++ b/cmd/php/webconfig/main.go
@@ -93,6 +93,11 @@ func buildFn(ctx *gcp.Context) error {
 	}
 	overrides.NginxServesStaticFiles = nginxServesStaticFiles
 
+	nginxDocumentRoot := os.Getenv(php.NginxDocumentRoot)
+	if (nginxDocumentRoot != "") {
+		overrides.DocumentRoot = nginxDocumentRoot
+	}
+
 	fpmConfFile, err := writeFpmConfig(ctx, l.Path, overrides)
 	if err != nil {
 		return err

--- a/pkg/php/php.go
+++ b/pkg/php/php.go
@@ -93,6 +93,9 @@ post_max_size = 32M
 
 	// NginxServesStaticFiles is an environment variable to configure Nginx to serve static files.
 	NginxServesStaticFiles = "NGINX_SERVES_STATIC_FILES"
+
+	// NginxDocumentRoot overrides the document root of nginx.
+	NginxDocumentRoot = "NGINX_DOCUMENT_ROOT"
 )
 
 type composerScriptsJSON struct {


### PR DESCRIPTION
There is a way to set document root for app engine using this buildpack via app.yaml, but we also need this ability outside app engine. So the solution here is to allow setting it via NGINX_DOCUMENT_ROOT environment variable.