### PR TITLE
Add PHP runtime configuration from composer.json

### DIFF
--- a/pkg/php/php.go
+++ b/pkg/php/php.go
@@ -99,10 +99,27 @@ type composerScriptsJSON struct {
 	GCPBuild string `json:"gcp-build"`
 }
 
+type composerExtraJSON struct {
+	GoogleBuildpacks composerExtraGoogleBuildpacksJSON `json:"google-buildpacks,omitempty"`
+}
+
+type composerExtraGoogleBuildpacksJSON struct {
+	DocumentRoot    string                                  `json:"document_root,omitempty"`
+	FrontController string                                  `json:"front_controller,omitempty"`
+	PHPFPM          composerExtraGoogleBuildpacksPHPFPMJSON `json:"php-fpm,omitempty"`
+	ServeStatic     bool                                    `json:"serve_static,omitempty"`
+}
+
+type composerExtraGoogleBuildpacksPHPFPMJSON struct {
+	EnableDynamicWorkers bool `json:"enable_dynamic_workers,omitempty"`
+	Workers              int  `json:"workers,omitempty"`
+}
+
 // ComposerJSON represents the contents of a composer.json file.
 type ComposerJSON struct {
 	Require map[string]string   `json:"require"`
 	Scripts composerScriptsJSON `json:"scripts"`
+	Extra   composerExtraJSON   `json:"extra,omitempty"`
 }
 
 // SupportsAppEngineApis is a function that returns true if App Engine API access is enabled

--- a/pkg/webconfig/webconfig.go
+++ b/pkg/webconfig/webconfig.go
@@ -44,6 +44,10 @@ type OverrideProperties struct {
 	NginxHTTPInclude bool
 	// NginxHTTPIncludeFileName name of the partial nginx config to be included in the http section.
 	NginxHTTPIncludeFileName string
+	// PHPFPMDynamicWorkers boolean to toggle dynamic workers in the php-fpm config file.
+	PHPFPMDynamicWorkers bool
+	// PHPFPMWorkers integer to specify the worker thread count in the php-fpm config file.
+	PHPFPMWorkers int
 	// PHPFPMOverride boolean to check if user-provided php-fpm config exists.
 	PHPFPMOverride bool
 	// PHPFPMOverrideFileName name of the user-provided php-fpm config file.
@@ -54,6 +58,23 @@ type OverrideProperties struct {
 	PHPIniOverrideFileName string
 	// NginxServesStaticFiles whether Nginx also serves static files for matching URIs.
 	NginxServesStaticFiles bool
+}
+
+func (op *OverrideProperties) PatchWithComposerConfig(ctx *gcp.Context, composerConfig *php.ComposerJSON) {
+	if len(composerConfig.Extra.GoogleBuildpacks.DocumentRoot) > 0 {
+		op.DocumentRoot = composerConfig.Extra.GoogleBuildpacks.DocumentRoot
+	}
+
+	if len(composerConfig.Extra.GoogleBuildpacks.FrontController) > 0 {
+		op.FrontController = composerConfig.Extra.GoogleBuildpacks.FrontController
+	}
+
+	op.PHPFPMDynamicWorkers = composerConfig.Extra.GoogleBuildpacks.PHPFPM.EnableDynamicWorkers
+	op.PHPFPMWorkers = composerConfig.Extra.GoogleBuildpacks.PHPFPM.Workers
+
+	if composerConfig.Extra.GoogleBuildpacks.ServeStatic {
+		op.NginxServesStaticFiles = composerConfig.Extra.GoogleBuildpacks.ServeStatic
+	}
 }
 
 // OverriddenProperties returns whether the property has been overridden and the path to the file.


### PR DESCRIPTION
To aid it a more idiomatic and friendly developer experience, when building for a PHP application, allow the runtime to be configured from `composer.json`, e.g.:

```json
{
    "require": {
        "php": "^8.3",
        "myorg/mypackage": "^0.7"
    },
    "scripts": {
        "gcp-build": "my-script"
    },
    "extra": {
        "laravel": {
            "dont-discover": [
                "myorg/mypackage"
            ]
        },
        "google-buildpacks": {
            "document_root": "public",
            "front_controller": "index.php",
            "php-fpm": {
                "enable_dynamic_workers": true,
                "workers": 4
            },
            "serve_static": true
        }
    }
}
```

You can omit this entirely, or omit individual fields, so just specify the bits you want to customise.

This should work for both App Engine Flex, plus Cloud Run.

RFC @sonnysasaka @sl0wik @jama22 @kennethye1 

I don't necessarily intend to have this merged as is, but use it as a starting point for a further discussion, unless you are all happy - what do we think?