### PR TITLE
Run npm ci with --no-audit and --no-fund

### DIFF
--- a/cmd/nodejs/npm/main.go
+++ b/cmd/nodejs/npm/main.go
@@ -127,7 +127,7 @@ func buildFn(ctx *gcp.Context) error {
 				return err
 			}
 
-			if _, err := ctx.Exec([]string{"npm", installCmd, "--quiet"}, gcp.WithEnv("NODE_ENV="+buildNodeEnv), gcp.WithUserAttribution); err != nil {
+			if _, err := ctx.Exec([]string{"npm", installCmd, "--quiet", "--no-fund", "--no-audit"}, gcp.WithEnv("NODE_ENV="+buildNodeEnv), gcp.WithUserAttribution); err != nil {
 				return err
 			}
 			// Ensure node_modules exists even if no dependencies were installed.


### PR DESCRIPTION
This is to avoid
```
12 packages are looking for funding
found 0 vulnerabilities
``` 

Which probably slows down the build process. In any case, these checks are not necessary in a CI/CD environment.

Note that these flags might not be present in all versions of Node.js, so this PR probably needs more logic to add / remove flags based on the version.

This hasn't been tested either.