### PR TITLE
fix(turborepo): respect GOOGLE_BUILDABLE from buildpack platform environment

### DIFF
--- a/cmd/nodejs/turborepo/lib/lib_test.go
+++ b/cmd/nodejs/turborepo/lib/lib_test.go
@@ -68,6 +68,31 @@ func TestBuild(t *testing.T) {
 			},
 		},
 		{
+			name: "reads_google_buildable_when_root_package_json_exists",
+			envs: []string{"GOOGLE_BUILDABLE=apps/my-app"},
+			files: map[string]string{
+				"index.js": "",
+				"package.json": `{
+					"name": "root-package"
+				}`,
+				"turbo.json": `{
+					"tasks": {
+						"build": {
+							"outputs": ["dist/**", ".next/**"],
+							"cache": true
+						}
+					}
+				}`,
+				"apps/my-app/package.json": `{
+					"name": "my-app"
+				}`,
+			},
+			wantExitCode: 0,
+			wantBuilderMetadata: map[bmd.MetadataID]bmd.MetadataValue{
+				bmd.MonorepoName: bmd.MetadataValue("turbo"),
+			},
+		},
+		{
 			name: "ambiguous_application_name",
 			files: map[string]string{
 				"index.js": "",

--- a/pkg/firebase/util/util.go
+++ b/pkg/firebase/util/util.go
@@ -34,7 +34,7 @@ var (
 // the application root by default.
 func ApplicationDirectory(ctx *gcp.Context) string {
 	appDir := ctx.ApplicationRoot()
-	if appDirEnv, exists := os.LookupEnv(env.Buildable); exists {
+	if appDirEnv := ctx.Env(env.Buildable); appDirEnv != "" {
 		appDir = filepath.Join(ctx.ApplicationRoot(), appDirEnv)
 	}
 	return appDir

--- a/pkg/gcpbuildpack/gcpbuildpack.go
+++ b/pkg/gcpbuildpack/gcpbuildpack.go
@@ -238,6 +238,17 @@ func (ctx *Context) ApplicationRoot() string {
 	return ctx.applicationRoot
 }
 
+// Env returns the value of the given environment variable. It first checks the
+// buildpack platform environment, then falls back to the OS process environment.
+func (ctx *Context) Env(key string) string {
+	if ctx.buildContext.Platform.Environment != nil {
+		if val, ok := ctx.buildContext.Platform.Environment[key]; ok {
+			return val
+		}
+	}
+	return os.Getenv(key)
+}
+
 // BuildpackRoot returns the root folder of the buildpack.
 func (ctx *Context) BuildpackRoot() string {
 	return ctx.buildpackRoot

--- a/pkg/gcpbuildpack/gcpbuildpack_test.go
+++ b/pkg/gcpbuildpack/gcpbuildpack_test.go
@@ -104,6 +104,51 @@ func TestNewContextWithBuildContext(t *testing.T) {
 	}
 }
 
+func TestEnv(t *testing.T) {
+	testCases := []struct {
+		name          string
+		platformEnv   map[string]string
+		osEnv         map[string]string
+		key           string
+		want          string
+	}{
+		{
+			name:        "platform_env_takes_precedence",
+			platformEnv: map[string]string{"GOOGLE_BUILDABLE": "apps/web"},
+			osEnv:       map[string]string{"GOOGLE_BUILDABLE": "apps/other"},
+			key:         "GOOGLE_BUILDABLE",
+			want:        "apps/web",
+		},
+		{
+			name:        "falls_back_to_os_env",
+			osEnv:       map[string]string{"GOOGLE_BUILDABLE": "apps/other"},
+			key:         "GOOGLE_BUILDABLE",
+			want:        "apps/other",
+		},
+		{
+			name:        "missing_env_returns_empty",
+			key:         "GOOGLE_BUILDABLE",
+			want:        "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.osEnv {
+				os.Setenv(k, v)
+				defer os.Unsetenv(k)
+			}
+			ctx := NewContext(WithBuildContext(libcnb.BuildContext{
+				Platform: libcnb.Platform{Environment: tc.platformEnv},
+			}))
+			got := ctx.Env(tc.key)
+			if got != tc.want {
+				t.Errorf("ctx.Env(%q) = %q, want %q", tc.key, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestDetectContextInitialized(t *testing.T) {
 	setUpDetectEnvironment(t)
 


### PR DESCRIPTION
The `google.nodejs.turborepo` buildpack was reading `GOOGLE_BUILDABLE` using `os.LookupEnv`, which only checks the OS process environment. In Firebase App Hosting, `GOOGLE_BUILDABLE` is injected via the buildpack **platform** environment, so the buildpack silently fell back to `ctx.ApplicationRoot()` and targeted the root `package.json` name instead of the intended workspace application.

This caused builds to fail with:
```
• turbo 2.9.6
  x No package found with name '<root-package-name>' in workspace
```

**Changes:**
- Add `Env()` to `gcpbuildpack.Context` that checks `Platform.Environment` first, then falls back to `os.Getenv`.
- Update `util.ApplicationDirectory()` to use `ctx.Env(env.Buildable)`.
- Add unit tests for `Env()` and for the turborepo buildpack scenario where a root `package.json` exists alongside a `GOOGLE_BUILDABLE` sub-application.

Fixes #623