### PR TITLE
Fix buildpack for PNPM version 11

### DIFF
--- a/pkg/nodejs/pnpm.go
+++ b/pkg/nodejs/pnpm.go
@@ -10,6 +10,7 @@ import (
 	gcp "github.com/GoogleCloudPlatform/buildpacks/pkg/gcpbuildpack"
 	"github.com/GoogleCloudPlatform/buildpacks/pkg/runtime"
 	"github.com/GoogleCloudPlatform/buildpacks/pkg/tooling"
+	"github.com/Masterminds/semver"
 	"github.com/buildpacks/libcnb/v2"
 )
 
@@ -26,8 +27,12 @@ var (
 	PNPMLock = "pnpm-lock.yaml"
 	// pnpmDownloadURL is the template used to generate a pnpm download URL.
 	pnpmDownloadURL = "https://github.com/pnpm/pnpm/releases/download/v%s/pnpm-linux-x64"
+	// pnpmTarballDownloadURL is the template used to generate a pnpm tarball download URL.
+	pnpmTarballDownloadURL = "https://github.com/pnpm/pnpm/releases/download/v%s/pnpm-linux-x64.tar.gz"
 	// pnpmVersionKey is the metadata key used to store the pnpm version in the pnpn layer.
 	pnpmVersionKey = "version"
+	// pnpmTarballVersion is the first version where pnpm publishes the Linux x64 asset as a tarball.
+	pnpmTarballVersion = semver.MustParse("11.0.0")
 )
 
 // InstallPNPM installs pnpm in the given layer if it is not already cached.
@@ -82,6 +87,14 @@ func InstallPNPM(ctx *gcp.Context, pnpmLayer *libcnb.Layer, pjs *PackageJSON) er
 func downloadPNPM(ctx *gcp.Context, dir, version string) error {
 	if err := ctx.MkdirAll(dir, 0755); err != nil {
 		return err
+	}
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return gcp.InternalErrorf("parsing pnpm version %q: %w", version, err)
+	}
+	if !v.LessThan(pnpmTarballVersion) {
+		url := fmt.Sprintf(pnpmTarballDownloadURL, version)
+		return fetch.Tarball(url, dir, 0)
 	}
 	fp := filepath.Join(dir, "pnpm")
 	url := fmt.Sprintf(pnpmDownloadURL, version)

--- a/pkg/nodejs/pnpm_test.go
+++ b/pkg/nodejs/pnpm_test.go
@@ -14,6 +14,9 @@
 package nodejs
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,11 +29,12 @@ import (
 
 func TestInstallPNPM(t *testing.T) {
 	testCases := []struct {
-		name        string
-		npmResponse string
-		packageJSON PackageJSON
-		wantFile    string
-		wantError   bool
+		name             string
+		npmResponse      string
+		pnpmResponseFile string
+		packageJSON      PackageJSON
+		wantFile         string
+		wantError        bool
 	}{
 		{
 			name:     "no version constraint",
@@ -73,6 +77,27 @@ func TestInstallPNPM(t *testing.T) {
 			},
 		},
 		{
+			name:             "pnpm 11 tarball",
+			pnpmResponseFile: createPnpmTarball(t),
+			wantFile:         "bin/dist/pnpm.mjs",
+			npmResponse: `{
+				"name": "pnpm",
+				"dist-tags": {
+					"latest": "11.1.1"
+				},
+				"versions": {
+					"11.1.1": {
+						"name": "npm",
+						"version": "11.1.1"
+					}
+				},
+				"modified": "2022-01-27T21:10:55.626Z"
+			}`,
+			packageJSON: PackageJSON{
+				PackageManager: "pnpm@11.1.1",
+			},
+		},
+		{
 			name: "invalid version",
 			npmResponse: `{
 				"name": "pnpm",
@@ -98,11 +123,19 @@ func TestInstallPNPM(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			testserver.New(
-				t,
-				testserver.WithJSON(`pnpm!`),
-				testserver.WithMockURL(&pnpmDownloadURL),
-			)
+			if tc.pnpmResponseFile != "" {
+				testserver.New(
+					t,
+					testserver.WithFile(tc.pnpmResponseFile),
+					testserver.WithMockURL(&pnpmTarballDownloadURL),
+				)
+			} else {
+				testserver.New(
+					t,
+					testserver.WithJSON(`pnpm!`),
+					testserver.WithMockURL(&pnpmDownloadURL),
+				)
+			}
 			testserver.New(
 				t,
 				testserver.WithJSON(tc.npmResponse),
@@ -128,6 +161,49 @@ func TestInstallPNPM(t *testing.T) {
 		})
 	}
 }
+
+func createPnpmTarball(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "pnpm-linux-x64.tar.gz")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("os.Create(%q): %v", path, err)
+	}
+	gzw := gzip.NewWriter(file)
+	tw := tar.NewWriter(gzw)
+
+	for _, entry := range []struct {
+		name string
+		mode int64
+		body string
+	}{
+		{name: "pnpm", mode: 0777, body: "pnpm!"},
+		{name: "dist/pnpm.mjs", mode: 0644, body: "console.log('pnpm')"},
+	} {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: entry.name,
+			Mode: entry.mode,
+			Size: int64(len(entry.body)),
+		}); err != nil {
+			t.Fatalf("writing tar header for %q: %v", entry.name, err)
+		}
+		if _, err := io.WriteString(tw, entry.body); err != nil {
+			t.Fatalf("writing tar body for %q: %v", entry.name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("closing tar writer: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("closing gzip writer: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("closing %q: %v", path, err)
+	}
+	return path
+}
+
 func TestDetectPNPMVersion(t *testing.T) {
 	testCases := []struct {
 		name        string


### PR DESCRIPTION
PNPM version 11 switches from releasing binaries directly to releasing them inside `.tar.gz` files.

Old release sample URL: https://github.com/pnpm/pnpm/releases/download/v10.33.4/pnpm-linux-x64

New release sample URL: https://github.com/pnpm/pnpm/releases/download/v11.1.1/pnpm-linux-x64.tar.gz

Related issue: https://github.com/GoogleCloudPlatform/buildpacks/issues/627
This MR does *not* fix old PNPM versions resolving to version 11.
It only fixes 404 errors when downloading PNPM version 11.