### PR TITLE
fix(nodejs/pnpm): generate Artifact Registry credentials before pnpm install

### DIFF
--- a/cmd/nodejs/pnpm/lib/lib.go
+++ b/cmd/nodejs/pnpm/lib/lib.go
@@ -17,10 +17,12 @@
 package lib
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/buildpacks/pkg/ar"
 	"github.com/GoogleCloudPlatform/buildpacks/pkg/buildermetadata"
 	"github.com/GoogleCloudPlatform/buildpacks/pkg/env"
 	"github.com/GoogleCloudPlatform/buildpacks/pkg/firebase/faherror"
@@ -68,6 +70,10 @@ func BuildFn(ctx *gcp.Context) error {
 
 	if err := installPNPM(ctx, pjs); err != nil {
 		return gcp.InternalErrorf("installing pnpm: %w", err)
+	}
+
+	if err := ar.GenerateNPMConfig(ctx); err != nil {
+		return fmt.Errorf("generating Artifact Registry credentials: %w", err)
 	}
 
 	if err := pnpmInstallModules(ctx, pjs); err != nil {

--- a/pkg/nodejs/pnpm_test.go
+++ b/pkg/nodejs/pnpm_test.go
@@ -99,6 +99,34 @@ func TestInstallPNPM(t *testing.T) {
 			},
 			wantError: true,
 		},
+		{
+			// Regression test for https://github.com/GoogleCloudPlatform/buildpacks/issues/627:
+			// a range constraint like ">=9.0.0" resolves to the highest matching version (v11),
+			// which must install via the tarball path rather than 404 on a missing naked binary.
+			name:     "version_range_resolves_to_v11",
+			wantFile: "bin/pnpm",
+			npmResponse: `{
+				"name": "pnpm",
+				"dist-tags": {
+					"latest": "11.0.0"
+				},
+				"versions": {
+					"9.15.0": {
+						"name": "pnpm",
+						"version": "9.15.0"
+					},
+					"11.0.0": {
+						"name": "pnpm",
+						"version": "11.0.0"
+					}
+				}
+			}`,
+			packageJSON: PackageJSON{
+				Engines: packageEnginesJSON{
+					PNPM: ">=9.0.0",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -299,28 +327,50 @@ func TestInstallPNPMV11(t *testing.T) {
 		t.Fatalf("InstallPNPM(ctx, %v, %+v) got error: %v, want nil", layer, pkgJSON, err)
 	}
 
+	// Verify the native binary was replaced with the bash wrapper that uses node to execute
+	// dist/pnpm.mjs, avoiding a libatomic dependency on minimal run images.
 	fp := filepath.Join(layer.Path, "bin/pnpm")
-	if _, err := os.Stat(fp); err != nil {
-		t.Errorf("os.Stat(%q) got error: %v, want nil", fp, err)
+	content, err := os.ReadFile(fp)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q) got error: %v, want nil", fp, err)
+	}
+	wantWrapper := "#!/usr/bin/env bash\nexec node \"$(dirname \"$0\")/dist/pnpm.mjs\" \"$@\"\n"
+	if string(content) != wantWrapper {
+		t.Errorf("bin/pnpm content = %q, want wrapper script %q", string(content), wantWrapper)
+	}
+
+	// Verify dist/pnpm.mjs was extracted from the tarball (present in all pnpm v11+ releases).
+	mjsFP := filepath.Join(layer.Path, "bin/dist/pnpm.mjs")
+	if _, err := os.Stat(mjsFP); err != nil {
+		t.Errorf("os.Stat(%q) got error: %v, want nil", mjsFP, err)
 	}
 }
 
+// mockTarballBytes returns a minimal .tar.gz that mirrors the flat structure of real pnpm v11+
+// release tarballs: a "pnpm" native binary at root and a "dist/pnpm.mjs" JS entry point.
 func mockTarballBytes(t *testing.T) []byte {
 	t.Helper()
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gw)
-	hdr := &tar.Header{
-		Name: "pnpm",
-		Mode: 0755,
-		Size: int64(len("pnpm!")),
-	}
-	if err := tw.WriteHeader(hdr); err != nil {
+
+	pnpmBin := []byte("pnpm!")
+	if err := tw.WriteHeader(&tar.Header{Name: "pnpm", Mode: 0755, Size: int64(len(pnpmBin))}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := tw.Write([]byte("pnpm!")); err != nil {
+	if _, err := tw.Write(pnpmBin); err != nil {
 		t.Fatal(err)
 	}
+
+	// dist/pnpm.mjs is present in every pnpm v11+ tarball and is referenced by the bash wrapper.
+	mjsContent := []byte("// pnpm.mjs")
+	if err := tw.WriteHeader(&tar.Header{Name: "dist/pnpm.mjs", Mode: 0644, Size: int64(len(mjsContent))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(mjsContent); err != nil {
+		t.Fatal(err)
+	}
+
 	tw.Close()
 	gw.Close()
 	return buf.Bytes()


### PR DESCRIPTION
## Summary

The pnpm buildpack was missing a call to `ar.GenerateNPMConfig`, which writes a user-level `.npmrc` with the auth token required for `pnpm install` to pull packages from Artifact Registry.

The npm buildpack already does this (see `cmd/nodejs/npm/lib/lib.go`):
```go
if err := ar.GenerateNPMConfig(ctx); err != nil {
    return fmt.Errorf("generating Artifact Registry credentials: %w", err)
}
```

pnpm reads the same `.npmrc` auth format as npm, so the identical call is all that is needed. This PR adds it to `BuildFn` immediately before `pnpmInstallModules`, mirroring the npm placement.

`ar.GenerateNPMConfig` is safe to add here:
- It is a no-op if a user-level `.npmrc` already exists (respects user-managed auth).
- It is a warn-only no-op when Application Default Credentials are absent (e.g. local dev), so it cannot break existing builds.

## Root cause

`ar.GenerateNPMConfig` scans the project-level `.npmrc` for Artifact Registry registry entries, fetches a short-lived OAuth token from ADC, and writes `//registry.url/:_authToken=<token>` into `~/.npmrc`. The pnpm buildpack never made this call, so any `pnpm install` that needed AR packages failed with an authentication error even though the same project deployed successfully with npm.

## Test plan

- [ ] Deploy a Cloud Run or Cloud Function service with a pnpm lockfile that includes a private package hosted in Artifact Registry — confirm the build succeeds.
- [ ] Confirm that pnpm builds with no Artifact Registry dependency are unaffected (GenerateNPMConfig is a no-op when no `.npmrc` AR entry is found).

Fixes #598