### PR TITLE
fix(nodejs/bun): generate Artifact Registry credentials before bun install

### DIFF
--- a/cmd/nodejs/bun/lib/lib.go
+++ b/cmd/nodejs/bun/lib/lib.go
@@ -17,10 +17,12 @@
 package lib
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/buildpacks/pkg/ar"
 	"github.com/GoogleCloudPlatform/buildpacks/pkg/buildermetadata"
 	"github.com/GoogleCloudPlatform/buildpacks/pkg/env"
 	"github.com/GoogleCloudPlatform/buildpacks/pkg/firebase/faherror"
@@ -71,6 +73,10 @@ func BuildFn(ctx *gcp.Context) error {
 
 	if err := installBun(ctx, pjs); err != nil {
 		return gcp.InternalErrorf("installing bun: %w", err)
+	}
+
+	if err := ar.GenerateNPMConfig(ctx); err != nil {
+		return fmt.Errorf("generating Artifact Registry credentials: %w", err)
 	}
 
 	if err := bunInstallModules(ctx); err != nil {


### PR DESCRIPTION
## Summary

The bun buildpack was the only Node.js package manager buildpack missing a call to `ar.GenerateNPMConfig`. This meant any bun-based deployment that depended on packages hosted in Artifact Registry would fail at `bun install` with an authentication error, even though identical npm, yarn, or pnpm deployments would succeed.

## Coverage gap

| Buildpack | `ar.GenerateNPMConfig` |
|-----------|------------------------|
| npm | ✅ `cmd/nodejs/npm/lib/lib.go:70` |
| yarn | ✅ `cmd/nodejs/yarn/lib/lib.go:163` |
| pnpm | ✅ `cmd/nodejs/pnpm/lib/lib.go` |
| functions_framework | ✅ `cmd/nodejs/functions_framework/lib/lib.go:270` |
| **bun** | ❌ **missing — this PR adds it** |

## Change

Added `ar.GenerateNPMConfig(ctx)` to `BuildFn` immediately before `bunInstallModules`, mirroring the placement used by npm and pnpm:

```go
if err := ar.GenerateNPMConfig(ctx); err != nil {
    return fmt.Errorf("generating Artifact Registry credentials: %w", err)
}
```

bun reads `~/.npmrc` for registry authentication (same format as npm/pnpm), so no bun-specific credential helper is needed — `GenerateNPMConfig` is sufficient.

## Safety

`ar.GenerateNPMConfig` is a no-op in these cases:
- A user-level `~/.npmrc` already exists (respects user-managed auth)
- No project-level `.npmrc` with AR registry entries is present
- Application Default Credentials are absent (logs a warning, does not fail the build)

Existing bun deployments without Artifact Registry dependencies are unaffected.

## Test plan

- [ ] Deploy a Cloud Run or Cloud Function service with a bun lockfile that includes a private package hosted in Artifact Registry — confirm the build succeeds.
- [ ] Confirm bun builds with no Artifact Registry dependency are unaffected.