### PR TITLE
fix(nodejs/bun): add vulnerability check and fix production entrypoint

### DIFF
--- a/cmd/nodejs/bun/lib/lib.go
+++ b/cmd/nodejs/bun/lib/lib.go
@@ -84,20 +84,34 @@ func BuildFn(ctx *gcp.Context) error {
 	el.SharedEnvironment.Prepend("PATH", string(os.PathListSeparator), filepath.Join(ctx.ApplicationRoot(), "node_modules", ".bin"))
 	el.SharedEnvironment.Default("NODE_ENV", nodejs.NodeEnv())
 
+	// Check for known vulnerable dependency versions (e.g. React2Shell / CVE-2025-55182).
+	nodeDeps, err := nodejs.ReadNodeDependencies(ctx, ctx.ApplicationRoot())
+	if err != nil {
+		ctx.Warnf("Failed to read node dependencies: %v", err)
+	} else {
+		if err := nodejs.CheckVulnerabilities(ctx, nodeDeps); err != nil {
+			return err
+		}
+	}
+
+	entrypoint, err := nodejs.Entrypoint(ctx, "bun")
+	if err != nil {
+		return err
+	}
+
 	devSync, err := env.IsDevSync()
 	if err != nil {
 		ctx.Warnf("Unable to determine dev sync status: %v", err)
 	} else if devSync {
-		cmd, err := nodejs.DevSyncEntrypoint(ctx, pjs, "bun")
+		entrypoint, err = nodejs.DevSyncEntrypoint(ctx, pjs, "bun")
 		if err != nil {
 			return gcp.InternalErrorf("getting dev sync entrypoint: %w", err)
 		}
-		ctx.AddWebProcess(cmd)
+		ctx.AddWebProcess(entrypoint)
 		return nil
 	}
 
-	// Configure the entrypoint for production.
-	ctx.AddWebProcess([]string{"npm", "run", "start"})
+	ctx.AddWebProcess(entrypoint)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Two gaps discovered by comparing the bun buildpack against the npm, yarn, and pnpm buildpacks.

### 1. Missing `CheckVulnerabilities`

Every other Node.js package manager buildpack checks for known-vulnerable dependency versions after install:

| Buildpack | `CheckVulnerabilities` |
|-----------|------------------------|
| npm | ✅ `cmd/nodejs/npm/lib/lib.go:150` |
| yarn | ✅ `cmd/nodejs/yarn/lib/lib.go:104` |
| pnpm | ✅ `cmd/nodejs/pnpm/lib/lib.go:89` |
| **bun** | ❌ **missing — this PR adds it** |

This check catches packages like `next` in the React2Shell / CVE-2025-55182 vulnerable range and blocks the build before deploying a vulnerable app. Bun-based deployments silently skipped this check entirely.

Added `ReadNodeDependencies` + `CheckVulnerabilities` using the same pattern as the pnpm buildpack.

### 2. Hardcoded `npm run start` entrypoint

The production entrypoint was hardcoded to `[]string{"npm", "run", "start"}` instead of using `nodejs.Entrypoint(ctx, "bun")`:

```go
// Before
ctx.AddWebProcess([]string{"npm", "run", "start"})

// After
entrypoint, err := nodejs.Entrypoint(ctx, "bun")
// ...
ctx.AddWebProcess(entrypoint)
```

This caused three problems:
- Runtime started via `npm`, not `bun`, even though bun was the declared package manager
- The `NPMStartEntrypointCapability` (used by the Maker tool) was ignored
- The devSync path used `bun` but the production path used `npm` — inconsistent

`nodejs.Entrypoint(ctx, "bun")` returns `["bun", "run", "start"]` in normal deployments, matching the convention used by yarn (`yarn run start`) and pnpm (`pnpm run start`).