### PR TITLE
fix(nodejs): versionFromNpmLock returns error on missing package

### DIFF
--- a/pkg/nodejs/nodejs.go
+++ b/pkg/nodejs/nodejs.go
@@ -437,7 +437,11 @@ func versionFromNpmLock(rawPackageLock []byte, pkg string) (string, error) {
 	if err := json.Unmarshal(rawPackageLock, &lockfile); err != nil {
 		return "", gcp.InternalErrorf("parsing lock file: %w", err)
 	}
-	return lockfile.Packages["node_modules/"+pkg].Version, nil
+	entry, ok := lockfile.Packages["node_modules/"+pkg]
+	if !ok || entry.Version == "" {
+		return "", gcp.InternalErrorf("Failed to find version for package %s in npm lockfile", pkg)
+	}
+	return entry.Version, nil
 }
 
 // Version tries to get the concrete package version used based on lock file.

--- a/pkg/nodejs/nodejs_test.go
+++ b/pkg/nodejs/nodejs_test.go
@@ -681,6 +681,36 @@ func TestVersion(t *testing.T) {
 			},
 			wantVersion: "17.3.6",
 		},
+		{
+			// Regression: versionFromNpmLock must return an error (not ("", nil)) when
+			// the package is absent, so callers fall back to package.json consistently
+			// with the pnpm and yarn lockfile parsers.
+			name: "Returns error for missing package in package-lock.json",
+			pkg:  "nonexistent-package",
+			nodeDeps: &NodeDependencies{
+				LockfilePath: testdata.MustGetPath("testdata/lock-files/nextjs-package-lock.json"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Returns error for missing package in pnpm-lock.yaml",
+			pkg:  "nonexistent-package",
+			nodeDeps: &NodeDependencies{
+				LockfilePath: testdata.MustGetPath("testdata/lock-files/nextjs-v9-pnpm-lock.yaml"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Returns error for missing package in yarn.lock",
+			pkg:  "nonexistent-package",
+			nodeDeps: &NodeDependencies{
+				PackageJSON: &PackageJSON{
+					Dependencies: map[string]string{},
+				},
+				LockfilePath: testdata.MustGetPath("testdata/lock-files/classic-yarn.lock"),
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Problem

`versionFromNpmLock` returned `("", nil)` when a package was absent from the npm lockfile. The pnpm and yarn lockfile parsers both return an error on miss:

| Parser | missing package | returns |
|--------|----------------|---------|
| `versionFromPnpmLock` | not in lockfile | `("", InternalError)` |
| `versionFromYarnLock` | not in lockfile | `("", InternalError)` |
| `versionFromNpmLock` | not in lockfile | **`("", nil)` ← bug** |

Callers rely on the error to fall back to `package.json`:

```go
// firebasenextjs/lib.go BuildFn
version, err := nodejs.Version(nodeDeps, "next")
if err != nil {
    // fallback to package.json — never reached for npm users on a miss
    version = nodeDeps.PackageJSON.Dependencies["next"]
}
```

For npm-lock users, a lockfile miss silently produces `version = ""` with no fallback, bypassing the `package.json` specifier that the user actually declared. The pnpm/yarn code paths correctly fall back.

## Fix

Explicit map-key check in `versionFromNpmLock`:

```go
entry, ok := lockfile.Packages["node_modules/"+pkg]
if !ok || entry.Version == "" {
    return "", gcp.InternalErrorf("Failed to find version for package %s in npm lockfile", pkg)
}
return entry.Version, nil
```

## Impact on callers

- **`firebasenextjs.BuildFn` / `DetectFn`**: now correctly falls back to `package.json` for npm users when the package is absent from the lockfile — consistent with pnpm/yarn behavior.
- **`CheckVulnerabilities`**: both old (`("", nil)`) and new (`("", error)`) skip the vulnerability check when the package is not found — functionally unchanged.

## Tests

Added three test cases documenting the "not found → error" contract for all three lockfile parsers so the invariant is enforced going forward. The npm case is the regression test (previously returned `wantErr: false`).

Related: #507