### PR TITLE
fix(python/uv): generate Artifact Registry credentials before uv install

### DIFF
--- a/cmd/python/uv/lib/BUILD.bazel
+++ b/cmd/python/uv/lib/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//:__subpackages__",
     ],
     deps = [
+        "//pkg/ar",
         "//pkg/buildermetadata",
         "//pkg/buildermetrics",
         "//pkg/gcpbuildpack",

--- a/cmd/python/uv/lib/lib.go
+++ b/cmd/python/uv/lib/lib.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/buildpacks/pkg/ar"
 	"github.com/GoogleCloudPlatform/buildpacks/pkg/buildermetadata"
 	"github.com/GoogleCloudPlatform/buildpacks/pkg/buildermetrics"
 	gcp "github.com/GoogleCloudPlatform/buildpacks/pkg/gcpbuildpack"
@@ -72,6 +73,13 @@ func BuildFn(ctx *gcp.Context) error {
 
 	if err := python.InstallUV(ctx); err != nil {
 		return fmt.Errorf("installing uv: %w", err)
+	}
+
+	// uv reads credentials from ~/.netrc, so generating the Artifact Registry
+	// config here covers both the pyproject.toml and the requirements.txt path
+	// below.
+	if err := ar.GeneratePythonConfig(ctx); err != nil {
+		return fmt.Errorf("generating Artifact Registry credentials: %w", err)
 	}
 
 	l, err := ctx.Layer(layerName, gcp.BuildLayer, gcp.CacheLayer, gcp.LaunchLayer)


### PR DESCRIPTION
Fixes #681.

## Problem

`cmd/python/uv/lib` never calls `ar.GeneratePythonConfig`, so `uv` runs without credentials for private Artifact Registry PyPI repositories and every install of a private package fails with `401 Unauthorized`.

| Path | `ar.GeneratePythonConfig` |
|------|---------------------------|
| `PIPInstallRequirements` | ✅ `pkg/python/python.go:237` |
| `PipInstallPyproject` | ✅ `pkg/python/pyproject.go:579` |
| `UVInstallDependenciesAndConfigureEnv` | ❌ before this change |
| `UVInstallRequirements` | ❌ before this change |

This matters beyond an opt-in feature, because uv is selected automatically: `IsUVPyproject` opts in whenever `pyproject.toml` + `uv.lock` are present, and uv is the default for `requirements.txt` on Python 3.14+. A project that adds a lock file or moves to 3.14 silently leaves the authenticated pip path.

## Change

One call in `BuildFn`, placed after `python.InstallUV` and before the layer is created — the same placement pattern as #643 / #645.

`cmd/python/uv/lib` is the only caller of both `UVInstallDependenciesAndConfigureEnv` and `UVInstallRequirements`, so a single call covers the pyproject.toml and the requirements.txt path without touching the shared `pkg/python` helpers.

`ar.GeneratePythonConfig` is safe here: it is a no-op when a `.netrc` already exists (`pkg/ar/ar.go:139`), so user-managed auth is respected, and a no-op when Application Default Credentials are absent (`pkg/ar/ar.go:150`), so local `pack` builds are unaffected.

`BUILD.bazel` gains `//pkg/ar` in `go_library` deps, which the Go import requires.

## Verification

Reproduced inside the actual GCF builder image, with the uv version this buildpack pins, running the exact command from `pkg/python/pyproject.go:341`. The only variable between the two runs is the presence of `~/.netrc` in the format written by `ar.writePythonConfig`.

Image: `europe-west1-docker.pkg.dev/serverless-runtimes/google-22-full/builder/python:python_20260805_RC00` (`sha256:3a21f5f011ddd91a218ae9877100b0519f97cb68024791e1ddcdb6793f1ef1b0`), uv 0.12.0, `uv sync --active --link-mode=copy`, a `pyproject.toml` + `uv.lock` with one dependency served only from a private AR repo.

**Without `.netrc`** — current behaviour:

```
  × Failed to download `private-package==X.Y.Z`
  ├─▶ Failed to fetch:
  │   `https://europe-west1-python.pkg.dev/PROJECT/REPO/private-package/private_package-X.Y.Z-py3-none-any.whl`
  ╰─▶ HTTP status client error (401 Unauthorized) for url
      (https://europe-west1-python.pkg.dev/PROJECT/REPO/private-package/private_package-X.Y.Z-py3-none-any.whl)
```

**With `.netrc`** — behaviour after this change:

```
 + private-package==X.Y.Z
 ... (all 54 packages installed)
```

This also answers the open question in #681 about astral-sh/uv#2822: the failing URL is the wheel path outside the `/simple/` index prefix, and `uv` does carry the `.netrc` credentials to it. No separate handling is needed.

The same 401 was observed end to end on a real `gcloud functions deploy` (gen2, `python313` runtime) before the change; the build log shows `google.python.uv 0.1.0` running `uv sync --active --link-mode=copy` with no credential step, and the build service account did hold `roles/artifactregistry.reader` on the repository.
