### PR TITLE
fix(nodejs/pnpm): generate Artifact Registry credentials before pnpm install

### DIFF
--- a/cmd/nodejs/pnpm/lib/BUILD.bazel
+++ b/cmd/nodejs/pnpm/lib/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//:__subpackages__",
     ],
     deps = [
+        "//pkg/ar",
         "//pkg/buildermetadata",
         "//pkg/env",
         "//pkg/firebase/faherror",

--- a/cmd/nodejs/pnpm/lib/lib.go
+++ b/cmd/nodejs/pnpm/lib/lib.go
@@ -17,10 +17,12 @@
 package lib
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/buildpacks/pkg/ar"
 	"github.com/GoogleCloudPlatform/buildpacks/pkg/buildermetadata"
 	"github.com/GoogleCloudPlatform/buildpacks/pkg/env"
 	"github.com/GoogleCloudPlatform/buildpacks/pkg/firebase/faherror"
@@ -72,6 +74,10 @@ func BuildFn(ctx *gcp.Context) error {
 
 	if err := installPNPM(ctx, pjs); err != nil {
 		return gcp.InternalErrorf("installing pnpm: %w", err)
+	}
+
+	if err := ar.GenerateNPMConfig(ctx); err != nil {
+		return fmt.Errorf("generating Artifact Registry credentials: %w", err)
 	}
 
 	if err := pnpmInstallModules(ctx, pjs); err != nil {


### PR DESCRIPTION
## Summary

The pnpm buildpack never generates Artifact Registry credentials, so `pnpm install` fetches private packages anonymously and fails:

```
Build failed with status: FAILURE and message: installing pnpm dependencies:
ERR_PNPM_FETCH_401  GET https://europe-npm.pkg.dev/<project>/<repo>/@scope/pkg/-/pkg-x.y.z.tgz: Unauthorized - 401
```

The npm and yarn buildpacks both call `ar.GenerateNPMConfig(ctx)` before installing dependencies (`cmd/nodejs/npm/lib/lib.go`, `cmd/nodejs/yarn/lib/lib.go`), which scans the project `.npmrc` for `*-npm.pkg.dev` registries and writes an auth token into the user-level `.npmrc`. pnpm reads the same user-level `.npmrc` format, so the identical call before `pnpm install` is sufficient.

This means any project with private Artifact Registry dependencies that migrates from npm/yarn to pnpm currently breaks on deploy to Cloud Run functions / Cloud Functions / App Hosting, with no workaround available inside the build (lifecycle scripts run after tarball fetching, which is the step that 401s).

## Changes

- `cmd/nodejs/pnpm/lib/lib.go`: call `ar.GenerateNPMConfig` after pnpm is installed and before `pnpm install`, mirroring the npm and yarn buildpacks.
- `cmd/nodejs/pnpm/lib/BUILD.bazel`: add the `//pkg/ar` dependency.

No new tests: `GenerateNPMConfig` behavior is covered by `pkg/ar/ar_test.go`, and neither the npm nor yarn buildpack tests this call at the buildpack level.

## Verification

Reproduced the failure by deploying Firebase Functions (nodejs24, 2nd gen) whose `package.json` depends on a private Artifact Registry package, with a `pnpm-lock.yaml` and a `.npmrc` containing the scoped registry line. Every function build fails with the `ERR_PNPM_FETCH_401` above; the same project deployed with `package-lock.json` (npm buildpack) succeeds with the identical `.npmrc`.

## Relation to #643

The core fix is the same as #643, which has been stale for more than 2 months on an unsigned CLA and we need this fixed — private Artifact Registry dependencies currently block any pnpm project from deploying. This PR additionally adds the `//pkg/ar` dependency to `BUILD.bazel`, which #643 is missing.

We have signed the Google CLA (corporate CLA covering the commit author email).

Fixes #598.
